### PR TITLE
Support callbacks with more than 1 response argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,14 @@ function callback() {
 
 promisfy(fs.readFile, fs);
 ```
+
+If your callback function expects more than just 2 arguments, the 2nd through nth arguments will be automatically bundled in an array when the promise resolves.
+```javascript
+foo(inputArg1, (error,responseArg1,responseArg2,responseArg3) => {})
+
+```
+can be promisfied like this:
+```javascript
+var [responseArg1,responseArg2,responseArg3] = await promisfy(foo)(inputArg1)
+
+```

--- a/index.js
+++ b/index.js
@@ -3,11 +3,15 @@ function promisfy(fn, ctx) {
         let args = arguments;
 
         return new Promise(function(resolve, reject) {
-            function callback(e, result) {
+            function callback(e, ...result) {
                 if (e) {
                     reject(e);
                 } else {
-                    resolve(result);
+                    if(result.length == 1){
+                        resolve(result[0]);
+                    }else{
+                        resolve(result);
+                    }
                 }
             }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promisfy",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "transform a node-style asynchronous function to promise-style function, very handy for async/await",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I need to support  functions that have more arguments than just `error` and `response`. They looks like this for example:
` trie.findPath(path, (error,branch,remainder,stack) => {}`
The above change is fully backward compatible but allows me to write clean code like this:
`    var [branch,remainder,stack] = await promisfy(trie.findPath, trie)(path)`

Also thanks for the repo. love the fact that its zero dependencies.